### PR TITLE
Fix Sphinx documentation building and deployment

### DIFF
--- a/.github/workflows/sphinx-gh-pages.yml
+++ b/.github/workflows/sphinx-gh-pages.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Generate Sphinx documentation
         uses: ammaraskar/sphinx-action@master
         with:
+          sphinx-version: "2.4.4"
           pre-build-command: "pip install sphinx_rtd_theme"
           docs-folder: "docs/sphinx/source"
           build-command: "sphinx-build -b html . ../build"

--- a/.github/workflows/sphinx-gh-pages.yml
+++ b/.github/workflows/sphinx-gh-pages.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Generate Sphinx documentation
         uses: ammaraskar/sphinx-action@master
         with:
-          sphinx-version: "2.4.4"
-          pre-build-command: "pip install sphinx_rtd_theme"
+          pre-build-command: "pip install sphinx_rtd_theme docutils==0.18.1"
           docs-folder: "docs/sphinx/source"
           build-command: "sphinx-build -b html . ../build"
 

--- a/.github/workflows/sphinx-gh-pages.yml
+++ b/.github/workflows/sphinx-gh-pages.yml
@@ -3,7 +3,8 @@ name: Sphinx documentation
 on:
   push:
     branches:
-      - noetic-devel
+      # - noetic-devel
+      - fix-documentation
 
 jobs:
   docs:
@@ -19,7 +20,7 @@ jobs:
         with:
           pre-build-command: "pip install sphinx_rtd_theme"
           docs-folder: "docs/sphinx/source"
-          build-command: "sphinx-build -b html . ../build -w /tmp/sphinx-log"
+          build-command: "sphinx-build -b html . ../build"
 
       - name: Deploy documentation in Github Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/sphinx-gh-pages.yml
+++ b/.github/workflows/sphinx-gh-pages.yml
@@ -3,8 +3,7 @@ name: Sphinx documentation
 on:
   push:
     branches:
-      # - noetic-devel
-      - fix-documentation
+      - noetic-devel
 
 jobs:
   docs:

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'xsens_mvn_ros'
-copyright = '2023, Mattia Leonori'
+copyright = '2024, Mattia Leonori'
 author = 'Mattia Leonori'
 release = '0.1.0'
 


### PR DESCRIPTION
 In this [Sphinx docs deploymentaction](https://github.com/hrii-iit/xsens_mvn_ros/actions/runs/7956047747/job/21716031266), we receive the following error:
```
ERROR: sphinx 7.1.2 has requirement docutils<0.21,>=0.18.1, but you'll have docutils 0.16 which is incompatible.
```
Installing the specific `docutils` version to 0.18.1, the Sphinx Documentation building and deployment works. 